### PR TITLE
Fix duplicate notifications across bots

### DIFF
--- a/app/settings.py
+++ b/app/settings.py
@@ -370,6 +370,13 @@ class Settings(BaseSettings):
         le=3600
     )
 
+    MESSAGE_DEDUP_TTL: int = Field(
+        default=120,
+        description="去重窗口，避免重复处理同一消息（秒）",
+        ge=30,
+        le=600
+    )
+
     MESSAGE_MAX_RETRIES: int = Field(
         default=3,
         description="消息处理最大重试次数",


### PR DESCRIPTION
## Summary
- add `CoordinationResult` to detect duplicates in message coordinator
- skip processing duplicate updates in `CoordinatedMessageHandler`
- treat duplicate coordination results as success in webhook logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684007a9239c8320ab21968e0195c269